### PR TITLE
Vastly improve the performance when the number of packets is large

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,158 @@
+{
+  "name": "bson-stream",
+  "version": "0.0.8",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "bson": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-0.4.23.tgz",
+      "integrity": "sha1-5louPHUH/63kEJvHV1p25Q+NqRU="
+    },
+    "commander": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
+      "integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM=",
+      "dev": true
+    },
+    "debug": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
+      "integrity": "sha1-ib2d9nMrUSVrxnBTQrugLtEhMe8=",
+      "dev": true,
+      "requires": {
+        "ms": "0.6.2"
+      }
+    },
+    "diff": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.8.tgz",
+      "integrity": "sha1-NDJ2MI7Jkbe8giZ+1VvBQR+XFmY=",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
+      "integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE=",
+      "dev": true
+    },
+    "glob": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
+      "integrity": "sha1-4xPusknHr/qlxHUoaw4RW1mDlGc=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "2.0.3",
+        "inherits": "2.0.3",
+        "minimatch": "0.2.14"
+      }
+    },
+    "graceful-fs": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
+      "integrity": "sha1-fNLNsiiko/Nule+mzBQt59GhNtA=",
+      "dev": true
+    },
+    "growl": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.8.1.tgz",
+      "integrity": "sha1-Sy3sjZB+k9szZiTc7AGDUC+MlCg=",
+      "dev": true
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "jade": {
+      "version": "0.26.3",
+      "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+      "integrity": "sha1-jxDXl32NefL2/4YqgbBRPMslaGw=",
+      "dev": true,
+      "requires": {
+        "commander": "0.6.1",
+        "mkdirp": "0.3.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+          "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+          "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
+          "dev": true
+        }
+      }
+    },
+    "lru-cache": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+      "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
+      "dev": true,
+      "requires": {
+        "lru-cache": "2.7.3",
+        "sigmund": "1.0.1"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+      "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "1.21.5",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-1.21.5.tgz",
+      "integrity": "sha1-fFiwkXTfl25DSiOx6NY5hz/FKek=",
+      "dev": true,
+      "requires": {
+        "commander": "2.3.0",
+        "debug": "2.0.0",
+        "diff": "1.0.8",
+        "escape-string-regexp": "1.0.2",
+        "glob": "3.2.3",
+        "growl": "1.8.1",
+        "jade": "0.26.3",
+        "mkdirp": "0.5.0"
+      }
+    },
+    "ms": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
+      "integrity": "sha1-2JwhJMb9wTU9Zai3e/GqxLGTcIw=",
+      "dev": true
+    },
+    "should": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/should/-/should-1.3.0.tgz",
+      "integrity": "sha1-ILcaCbXtFhRrkDAivTBu8zLv6HM=",
+      "dev": true
+    },
+    "sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+      "dev": true
+    }
+  }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -295,8 +295,9 @@ describe('BSONStream', function() {
   });
 
   it('receive a large document relatively fast', function(done) {
+    this.timeout(5000);
     var bs = new BSONStream();
-    var data = { foo: (new Array(300 * 1000)).fill(0) };
+    var data = { foo: (new Array(1000 * 1000)).fill(0) };
     bs.on('data', function(obj) {
       should.deepEqual(obj, data);
       done();

--- a/test/index.js
+++ b/test/index.js
@@ -293,4 +293,14 @@ describe('BSONStream', function() {
       bs.end(BSON.serialize(obj));
     });
   });
+
+  it('receive a large document relatively fast', function(done) {
+    var bs = new BSONStream();
+    var data = { foo: (new Array(300 * 1000)).fill(0) };
+    bs.on('data', function(obj) {
+      should.deepEqual(obj, data);
+      done();
+    });
+    bs.end(BSON.serialize(data));
+  });
 });


### PR DESCRIPTION
Currently when the incoming stream is large (and segmented into e.g. more than 10,000 packets), `Buffer.concat` gets called every iteration. This *dramatically* slows down data reception and results in minutes of local transmission for a 40MB document. The speed could be greatly improved by maintaining a buffer array, and only concatenate it at the complete reception of a document.

I observed at least ten times speed improvement on a document that is 40MB in size.